### PR TITLE
Add shinythemes to required packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Then, run server.R in an R IDE (such as Rstudio). This app has to be run locally
 This app requires a few packages that might need to be downloaded: <br>
 * [`leaflet`](https://github.com/rstudio/leaflet) and [`leaflet.extras`](https://github.com/bhaskarvk/leaflet.extras): These are responsible for the map and its features.
 * [`neonUtilities`](https://github.com/NEONScience/NEON-utilities/tree/master/neonUtilities) and [`nneo`](https://github.com/ropensci/nneo): used to pull datasets from NEON.
+* [`shinythemes`](https://github.com/rstudio/shinythemes): alter the appearance of the Shiny app. 
 * [`shinyWidgets`](https://github.com/dreamRs/shinyWidgets): provides costumized and "pimp[ed]" up widgets for shiny.
 * [`sf`](https://github.com/r-spatial/sf) and [`rgdal`](https://github.com/cran/rgdal): provide access to simple feature geometries.
 * [`jsonlite`](https://github.com/cran/jsonlite): helps deal with JSON structures.


### PR DESCRIPTION
Very interested in this Shiny app!  When installing also needed to have `shinythemes` installed, so I'd recommend adding it to the list here in the README.